### PR TITLE
docker machine names is idmapPING_* not idmap_*

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,18 @@ What did just happen:
 
 #### Initialize Database
 ```
-docker exec -it idmap_web_1 python manage.py migrate
+docker exec -it idmapping_db_1 python manage.py migrate
 ```
 
 #### Create Superuser
 ```
-docker exec -it idmap_web_1 python manage.py createsuperuser
+docker exec -it idmapping_web_1 python manage.py createsuperuser
 ```
 Follow the prompt to enter the admin info.
 
 #### Connect to Mongo instance
 ```
-docker exec -it idmap_db_1 mongo
+docker exec -it idmapping_db_1 mongo
 ```
 #### Load Fixtures
 ```


### PR DESCRIPTION
```
docker exec -it idmap_web_1 python manage.py migrate
Error response from daemon: no such id: idmap_web_1
```

`docker ps -a`

```
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                  NAMES
2d0e11d739d2        idmapping_web       "supervisord -n"         12 minutes ago      Up 12 minutes       0.0.0.0:8000->80/tcp   idmapping_web_1
eab6e1e1c885        mongo               "/entrypoint.sh mongo"   12 minutes ago      Up 12 minutes       27017/tcp              idmapping_db_1
```

This PR updates the readme to reflect the names of the containers
